### PR TITLE
adding unassigned publishers from my own library

### DIFF
--- a/publishers.json
+++ b/publishers.json
@@ -20,7 +20,11 @@
       "inxile entertainment",
       "Tiger Style Games",
       "Revolution Software",
-      "Paradox Interactive"
+      "Paradox Interactive",
+      "Lazy 8 Studios",
+      "Omni Systems",
+      "Cipher Prime Studios",
+      "Limbic"
     ]
   },
   "pc_games": {
@@ -29,7 +33,14 @@
       "electronic arts",
       "jackbox games",
       "harebrained schemes",
-      "Paradox Interactive"
+      "Paradox Interactive",
+      "Remedy Entertainment"
+    ]
+  },
+  "pc_software" :{
+    "display_name": "PC Software",
+    "publishers": [
+        "CyberLink"
     ]
   }
 }


### PR DESCRIPTION
```C:\Users\jed.mitten\Documents\GitHub\hb_library_catalog (jm_publishers_20171228 -> origin)
λ python -m unittest discover testing\
...No handlers could be found for logger "create_catalog"
.
----------------------------------------------------------------------
Ran 4 tests in 0.003s

OK```